### PR TITLE
CI: add `zig build` and `reuse lint` to GitHub Actions

### DIFF
--- a/.github/workflows/reuse_lint.yaml
+++ b/.github/workflows/reuse_lint.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+jobs:
+  compliance:
+    runs-on: ubuntu-24.04
+    name: Check for compliance
+    steps:
+      - name: Checkout last commit
+        uses: actions/checkout@v4
+      - name: Lint missing copyright and licensing information
+        uses: fsfe/reuse-action@v5

--- a/.github/workflows/zig_build.yaml
+++ b/.github/workflows/zig_build.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024 Eric Joldasov
+# SPDX-License-Identifier: CC0-1.0
+
+name: Zig
+on:
+  push:
+    branches: [ $default-branch ]
+    paths-ignore:
+      - "LICENSE/**"
+      - "README.md"
+      - ".gitignore"
+  pull_request:
+    branches: [ $default-branch ]
+    paths-ignore:
+      - "LICENSE/**"
+      - "README.md"
+      - ".gitignore"
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15]
+    name: Build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout last commit
+        uses: actions/checkout@v4
+      - name: Setup Zig nightly
+        uses: mlugg/setup-zig@v1
+        with:
+          version: master
+      - run: zig build


### PR DESCRIPTION
* `zig build` tested for native `x86_64-linux` (Ubuntu 22.04), `x86_64-windows` (Windows 2022), and `aarch64-macos` (macos-15).
* Additionally, `reuse lint` is reported.