### PR TITLE
 [TODO] [WIP] Use non-existant `zig.eclass` mechanism to make conditional deps

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -337,9 +337,6 @@ pub fn main() !void {
                         break :check_hash true;
                 } else break :check_hash false;
             };
-            // TODO need some mechanism for "zig.eclass" maybe?
-            // so that we can make conditional deps here.
-            // For now all dependencies are assumed as used.
             _ = used;
 
             switch (package.kind) {


### PR DESCRIPTION
I want to see something like this in the end:
```bash
declare -g -r -A ZBS_DEPENDENCIES=(
    [some-name-1.tar.gz]='some_url_1'
    
    # These dependencies were not used during
    # build with following args:
    # --system "..." -fno-sys=oniguruma <zig_build_additional_args without -fsys/-f-nosys>
    # Not commented yet since this can be false negative, check later.
    [some-name-2.tar.gz]='some_url_2'
)
```

Maybe allow multiple `zig_build_additional_args` so that multiple lines can be written and all used dependencies from each case intersected:

```bash
$ zig-ebuilder --zig_build_additional_args -Denable-tracy=true --zig_build_additional_args -Denable-tracy=false

declare -g -r -A ZBS_DEPENDENCIES=(
    [some-name-1.tar.gz]='some_url_1'
    
    # These dependencies were used during some
    # but not all builds, with following args:
    # --system "..." -Denable-tracy=false
    # Not used for following args:
    # --system "..." -Denable-tracy=true
    [some-name-2.tar.gz]='some_url_2'
    
    # These dependencies were not used during
    # all builds, with following args:
    # --system "..." -Denable-tracy=false
    # --system "..." -Denable-tracy=true
    # Not commented yet since this can be false negative, check later.
    [some-name-3.tar.gz]='some_url_3'
)
```